### PR TITLE
Move websocket logic to separate thread

### DIFF
--- a/src/automation.cpp
+++ b/src/automation.cpp
@@ -1,5 +1,5 @@
 #include "automation.h"
-#include "streaming.h"
+#include "stream_writer.h"
 #include "types.h"
 
 #include <OP/OP_Director.h>

--- a/src/interrupt.h
+++ b/src/interrupt.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "streaming.h"
+#include "stream_writer.h"
 
 #include <UT/UT_Interrupt.h>
 #include <chrono>

--- a/src/stream_writer.cpp
+++ b/src/stream_writer.cpp
@@ -1,5 +1,5 @@
 #include "mongoose.h"
-#include "streaming.h"
+#include "stream_writer.h"
 
 #include <iostream>
 
@@ -27,5 +27,5 @@ void StreamWriter::writeToStream(const std::string& op, const std::string& data)
 {
     std::cout << "Worker: Sending response: " << op << " " << data << std::endl;
     std::string json = "{\"op\":\"" + op + "\",\"data\":\"" + data + "\"}\n";
-    mg_ws_send(m_conn, json.c_str(), json.size(), WEBSOCKET_OP_TEXT);
+    m_websocket.push_response(StreamMessage{m_connection_id, json});
 }

--- a/src/stream_writer.h
+++ b/src/stream_writer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "websocket.h"
+
 #include <string>
 
 enum class AutomationState
@@ -11,7 +13,9 @@ enum class AutomationState
 class StreamWriter
 {
 public:
-    StreamWriter(struct mg_connection* conn) : m_conn(conn) {}
+    StreamWriter(WebSocket& websocket, int connection_id) 
+        : m_websocket(websocket), m_connection_id(connection_id) 
+    {}
 
     void state(AutomationState state);
     void status(const std::string& message);
@@ -21,5 +25,6 @@ public:
 private:
     void writeToStream(const std::string& op, const std::string& data);
 
-    struct mg_connection* m_conn;
+    WebSocket& m_websocket;
+    int m_connection_id;
 };

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -1,0 +1,140 @@
+#include "websocket.h"
+
+#include "mongoose.h"
+
+#include <iostream>
+#include <mutex>
+
+struct WebSocketThreadConfig
+{
+    std::string m_url;
+    int m_port;
+    MessageQueue& m_queue;
+};
+
+struct WebSocketThreadState
+{
+    std::map<int, struct mg_connection*> connection_map;
+    MessageQueue& m_queue;
+};
+
+static void fn_ws(struct mg_connection* c, int ev, void* ev_data)
+{ 
+    WebSocketThreadState* state = (WebSocketThreadState*)c->fn_data;
+
+    if (ev == MG_EV_OPEN)
+    {
+        std::cout << "Worker: Connection opened " << c->id << std::endl;
+        state->connection_map[c->id] = c;
+    }
+    else if (ev == MG_EV_HTTP_MSG)
+    {
+        struct mg_http_message* hm = (struct mg_http_message*)ev_data;
+        mg_ws_upgrade(c, hm, NULL);
+    }
+    else if (ev == MG_EV_WS_MSG)
+    {
+        struct mg_ws_message* wm = (struct mg_ws_message*) ev_data;
+        
+        std::string message(wm->data.buf, wm->data.len);
+        std::cout << "Worker: Received message: " << message << std::endl;
+
+        StreamMessage msg;
+        msg.connection_id = c->id;
+        msg.message = message;
+
+        state->m_queue.push_request(msg);
+    }
+    else if (ev == MG_EV_CLOSE)
+    {
+        std::cout << "Worker: Connection closed " << c->id << std::endl;
+        state->connection_map.erase(c->id);
+    }
+}
+
+static void websocket_thread(const WebSocketThreadConfig& config)
+{
+    WebSocketThreadState state{{}, config.m_queue};
+
+    struct mg_mgr mgr;
+    mg_mgr_init(&mgr);
+
+    std::string listen_addr = std::string("ws://") + config.m_url + ":" + std::to_string(config.m_port);
+    mg_http_listen(&mgr, listen_addr.c_str(), fn_ws, &state);
+
+    while (true)
+    {
+        StreamMessage response;
+        while (config.m_queue.try_pop_response(response))
+        {
+            auto it = state.connection_map.find(response.connection_id);
+            if (it != state.connection_map.end())
+            {
+                mg_ws_send(it->second, response.message.c_str(), response.message.length(), WEBSOCKET_OP_TEXT);
+            }
+            else
+            {
+                std::cout << "Worker: Response for unknown connection " << response.connection_id << std::endl;
+            }
+        }
+
+        mg_mgr_poll(&mgr, 10);
+    }
+
+    mg_mgr_free(&mgr);
+}
+
+void MessageQueue::push_request(const StreamMessage& message)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_requests.push(message);
+}
+
+void MessageQueue::push_response(const StreamMessage& message)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_responses.push(message);
+}
+
+bool MessageQueue::try_pop_request(StreamMessage& message)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_requests.empty())
+        return false;
+
+    message = m_requests.front();
+    m_requests.pop();
+    return true;
+}
+
+bool MessageQueue::try_pop_response(StreamMessage& message)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_responses.empty())
+        return false;
+
+    message = m_responses.front();
+    m_responses.pop();
+    return true;
+}
+
+WebSocket::WebSocket(const std::string& url, int port)
+{
+    WebSocketThreadConfig config = { url, port, m_queue };
+    m_thread = std::thread([config]{ websocket_thread(config); });
+}
+
+WebSocket::~WebSocket()
+{
+    m_thread.join();
+}
+
+bool WebSocket::try_pop_request(StreamMessage& message)
+{
+    return m_queue.try_pop_request(message);
+}
+
+void WebSocket::push_response(const StreamMessage& message)
+{
+    m_queue.push_response(message);
+}

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <queue>
+
+struct StreamMessage
+{
+    int connection_id;
+    std::string message;
+};
+
+class MessageQueue
+{
+public:
+    void push_request(const StreamMessage& message);
+    void push_response(const StreamMessage& message);
+    bool try_pop_request(StreamMessage& message);
+    bool try_pop_response(StreamMessage& message);
+
+private:
+    std::mutex m_mutex;
+    std::queue<StreamMessage> m_requests;
+    std::queue<StreamMessage> m_responses;
+};
+
+class WebSocket
+{
+public:
+    WebSocket(const std::string& url, int port);
+    ~WebSocket();
+
+    bool try_pop_request(StreamMessage& message);
+    void push_response(const StreamMessage& message);
+
+private:
+    std::thread m_thread;
+    MessageQueue m_queue;
+};


### PR DESCRIPTION
Currently this is using polling for the thread synchronization. In a follow up PR I will change this to by signal based to remove the poll delay.

We can also change this to a lock-free queue in the future.