### PR TITLE
Fix MainThread->WebSocketThread poll delay

### DIFF
--- a/src/websocket.h
+++ b/src/websocket.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "mongoose.h"
+
 #include <condition_variable>
 #include <map>
 #include <mutex>
@@ -39,6 +41,8 @@ public:
     void push_response(const StreamMessage& message);
 
 private:
+    mg_mgr m_mgr;
+
     std::thread m_thread;
     MessageQueue m_queue;
 };


### PR DESCRIPTION
See: https://mongoose.ws/documentation/tutorials/core/multi-threaded/

I am making the assumption that it is safe to construct the mg_mgr object on the main thread, and then hand it off to the worker thread to connect/poll. Logic can be re-arranged to avoid that if it becomes an issue.