### PR TITLE
Fix license leaking when running the container manually

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,6 @@ cleanup() {
     kill $WORKER_PID
     hserver -Q
     echo "Finished cleanup."
-    exit 0
 }
 
 trap cleanup TERM INT


### PR DESCRIPTION
The cleanup trap wasn't running when killing the container running in interative mode. When using Ctrl+C to quit the container, it sends an INT signal rather than a TERM.