### PR TITLE
Fix missing jemalloc lib error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,11 @@ target_include_directories(mongoose PUBLIC
 if(APPLE)
     # Use specific path for macOS builds
     set(Houdini_DIR "/Applications/Houdini/Houdini20.5.410/Frameworks/Houdini.framework/Versions/20.5/Resources/toolkit/cmake")
+    set(JEMALLOC_LIB "/Applications/Houdini/Houdini20.5.410/Frameworks/Houdini.framework/Versions/20.5/Resources/dsolib/libjemalloc.so")
 else()
     # For non-macOS platforms, use the HFS environment variable
     set(Houdini_DIR "$ENV{HFS}/toolkit/cmake")
+    set(JEMALLOC_LIB "$ENV{HFS}/dsolib/libjemalloc.so")
 endif()
 
 find_package(Houdini REQUIRED)
@@ -28,10 +30,11 @@ set(executable_name houdini_worker)
 add_executable(${executable_name} ${SOURCES}
         third_party/utest/utest.h)
 
-target_link_libraries(${executable_name} 
-    Houdini 
+target_link_libraries(${executable_name}
+    Houdini
     HoudiniThirdParty
     mongoose
+    ${JEMALLOC_LIB}
 )
 
 # Configure target properties


### PR DESCRIPTION
This warning was being printed on startup:

WARNING: JE Malloc not configured.
         Excessive memory fragmentation and poor performance may result.
         If this is intentional, set
             HOUDINI_DISABLE_JEMALLOCTEST=1
         to remove this warning.