### PR TITLE
Fix vertex data not updating correctly

### DIFF
--- a/test_client.html
+++ b/test_client.html
@@ -373,6 +373,16 @@
     vertexData.normals = normals;
     vertexData.uvs = uvs;
 
+    if (customMesh) {
+      const currentVertexCount = customMesh.getTotalVertices();
+      const newVertexCount = vertices.length / 3;
+
+      if (currentVertexCount !== newVertexCount) {
+        customMesh.dispose();
+        customMesh = null;
+      }
+    }
+
     if (!customMesh) {
       customMesh = new BABYLON.Mesh("customMesh", scene);
       customMesh.material = objectMaterial;


### PR DESCRIPTION
updateMesh can apparently only be used if the vertex count didn't change. 

There seems to be some strange lag when rapidly recreating the mesh which doesn't exist when you use the update path. Will look into if there is a different option for fixing this lag.