### PR TITLE
Expose cook errors to client

### DIFF
--- a/src/automation.cpp
+++ b/src/automation.cpp
@@ -556,6 +556,15 @@ bool cook(HoudiniSession& session, const CookRequest& request, StreamWriter& wri
             writer.error("Failed to cook node");
             return false;
         }
+
+        UT_Array<UT_Error> errors;
+        node->getRawErrors(errors, true);
+        for (const UT_Error& error : errors)
+        {
+            UT_String error_message;
+            error.getErrorMessage(error_message, UT_ERROR_NONE, true);
+            writer.error(std::string(error_message.c_str()));
+        }
     }
 
     // Export results

--- a/src/stream_writer.cpp
+++ b/src/stream_writer.cpp
@@ -4,6 +4,7 @@
 #include "util.h"
 #include "websocket.h"
 #include <UT/UT_Base64.h>
+#include <UT/UT_JSONValue.h>
 #include <UT/UT_WorkBuffer.h>
 
 #include <iostream>
@@ -15,12 +16,16 @@ void StreamWriter::state(AutomationState state)
 
 void StreamWriter::status(const std::string& message)
 {
-    writeToStream("status", "\"" + message + "\"");
+    UT_JSONValue json;
+    json.setString(message);
+    writeToStream("status", json.toString().c_str());
 }
 
 void StreamWriter::error(const std::string& message)
 {
-    writeToStream("error", "\"" + message + "\"");
+    UT_JSONValue json;
+    json.setString(message);
+    writeToStream("error", json.toString().c_str());
 }
 
 void StreamWriter::file(const std::string& file_name, const std::vector<char>& file_data)


### PR DESCRIPTION
Also needed to ensure characters inside the error message are escaped correctly before writing into json.