### PR TITLE
Refactor file_upload request to prepare for file_resolve request implementation

### DIFF
--- a/src/file_cache.cpp
+++ b/src/file_cache.cpp
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <regex>
 #include <unistd.h>
 #include <UT/UT_SHA256.h>
 #include <UT/UT_Base64.h>
@@ -17,8 +18,37 @@ FileCache::FileCache()
     m_cache_dir = cache_dir.string();
 }
 
-bool FileCache::add_file(const std::string& file_path, const std::string& content_base64)
+std::string parse_mime_type_extension(const std::string& mime_type)
 {
+    // This regex matches the format "type/subtype" and captures the subtype.
+    // ^[^/]+/    => matches one or more characters that are not '/' (the type), followed by a '/'
+    // ([^;]+)    => captures one or more characters that are not ';' (the subtype)
+    std::regex mimeRegex(R"(^[^/]+/([^;]+))");
+    std::smatch match;
+    return std::regex_search(mime_type, match, mimeRegex) ? match[1].str() : "";
+}
+
+bool FileCache::add_file(const std::string& file_id, const std::string& file_path)
+{
+    if (!std::filesystem::exists(file_path))
+    {
+        util::log() << "File does not exist: " << file_path << std::endl;
+        return false;
+    }
+
+    m_file_by_id[file_id] = file_path;
+    return true;
+}
+
+bool FileCache::add_file(const std::string& file_id, const std::string& content_type, const std::string& content_base64)
+{
+    std::string extension = parse_mime_type_extension(content_type);
+    if (extension.empty())
+    {
+        util::log() << "Invalid MIME type format: " << content_type << std::endl;
+        return false;
+    }
+
     // Decode base64 content
     UT_WorkBuffer decoded;
     if (!UT_Base64::decode(UT_StringView(content_base64.c_str()), decoded))
@@ -33,16 +63,7 @@ bool FileCache::add_file(const std::string& file_path, const std::string& conten
     std::string hash = hash_result.toStdString();
 
     // Store file using the original file extension
-    std::string extension;
-    size_t dot_pos = file_path.find_last_of('.');
-    if (dot_pos == std::string::npos)
-    {
-        util::log() << "File has no extension: " << file_path << std::endl;
-        return false;
-    }
-    extension = file_path.substr(dot_pos);
-
-    std::string resolved_path = (std::filesystem::path(m_cache_dir) / (hash + extension)).string();
+    std::string resolved_path = (std::filesystem::path(m_cache_dir) / (hash + "." + extension)).string();
 
     // Store the file content if it's not already cached
     if (m_file_by_hash.find(hash) == m_file_by_hash.end())
@@ -60,11 +81,9 @@ bool FileCache::add_file(const std::string& file_path, const std::string& conten
         }
 
         m_file_by_hash[hash] = resolved_path;
-        util::log() << "File cached: " << resolved_path << std::endl;
     }
 
-    m_file_by_path[file_path] = resolved_path;
-    util::log() << "Recorded cache reference: " << file_path << " -> " << resolved_path << std::endl;
+    m_file_by_id[file_id] = resolved_path;
     return true;
 }
 
@@ -74,8 +93,8 @@ std::string FileCache::get_file_by_hash(const std::string& hash)
     return iter != m_file_by_hash.end() ? iter->second : "";
 }
 
-std::string FileCache::get_file_by_path(const std::string& file_path)
+std::string FileCache::get_file_by_id(const std::string& file_id)
 {
-    auto iter = m_file_by_path.find(file_path);
-    return iter != m_file_by_path.end() ? iter->second : "";
+    auto iter = m_file_by_id.find(file_id);
+    return iter != m_file_by_id.end() ? iter->second : "";
 }

--- a/src/file_cache.h
+++ b/src/file_cache.h
@@ -8,12 +8,14 @@ class FileCache
 public:
     FileCache();
 
-    bool add_file(const std::string& file_path, const std::string& content_base64);
-    std::string get_file_by_hash(const std::string& hash);
-    std::string get_file_by_path(const std::string& file_path);
+    bool add_file(const std::string& file_id, const std::string& file_path);
+    bool add_file(const std::string& file_id, const std::string& content_type, const std::string& content_base64);
+    std::string get_file_by_id(const std::string& file_id);
 
 private:
+    std::string get_file_by_hash(const std::string& hash);
+
     std::string m_cache_dir;
     std::map<std::string, std::string> m_file_by_hash;
-    std::map<std::string, std::string> m_file_by_path;
+    std::map<std::string, std::string> m_file_by_id;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,14 @@ static void process_message(HoudiniSession& session, FileCache& file_cache, cons
     else if (std::holds_alternative<FileUploadRequest>(request))
     {
         FileUploadRequest& file_upload_req = std::get<FileUploadRequest>(request);
-        file_cache.add_file(file_upload_req.file_path, file_upload_req.content_base64);
+        if (!file_upload_req.file_path.empty())
+        {
+            file_cache.add_file(file_upload_req.file_id, file_upload_req.file_path);
+        }
+        else
+        {
+            file_cache.add_file(file_upload_req.file_id, file_upload_req.content_type, file_upload_req.content_base64);
+        }
     }
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -68,9 +68,16 @@ struct CookRequest
     EOutputFormat format;
 };
 
+struct FileResolveRequest
+{
+    std::string file_id;
+};
+
 struct FileUploadRequest
 {
+    std::string file_id;
     std::string file_path;
+    std::string content_type;
     std::string content_base64;
 };
 

--- a/test_client.html
+++ b/test_client.html
@@ -631,7 +631,8 @@
             const uploadMessage = {
               "op": "file_upload",
               "data": {
-                "file_path": `assets/${guidFileName}`,
+                "file_id": "file_input0",
+                "content_type": "application/usdz",
                 "content_base64": base64Content
               }
             };
@@ -639,8 +640,7 @@
             ws.send(JSON.stringify(uploadMessage));
 
             paramValues[key] = {
-              file_id: "file_xxx",
-              file_path: `assets/${guidFileName}`
+              file_id: "file_input0",
             };
             regenerateMesh();
           };

--- a/test_client.py
+++ b/test_client.py
@@ -101,6 +101,7 @@ async def main():
             return completed
 
         # Upload HDA file
+        hda_file_id = "file_test_hda"
         hda_path = "assets/test_cube.hda"
         base64_content = None
         with open(hda_path, "rb") as f:
@@ -110,7 +111,8 @@ async def main():
         upload_message = {
             "op": "file_upload",
             "data": {
-                "file_path": hda_path,
+                "file_id": hda_file_id,
+                "content_type": "application/hda",
                 "content_base64": base64_content
             }
         }
@@ -122,6 +124,7 @@ async def main():
         log.info("HDA file uploaded")
 
         # Upload USDZ file
+        input_file_id = "file_test_input0"
         input_path = "assets/cube.usdz"
         base64_content = None
         with open(input_path, "rb") as f:
@@ -131,7 +134,8 @@ async def main():
         upload_message = {
             "op": "file_upload",
             "data": {
-                "file_path": input_path,
+                "file_id": input_file_id,
+                "content_type": "application/usdz",
                 "content_base64": base64_content
             }
         }
@@ -147,14 +151,12 @@ async def main():
             "op": "cook",
             "data": {
                 "hda_path": {
-                    "file_id": "file_xxx",
-                    "file_path": hda_path
+                    "file_id": hda_file_id,
                 },
                 "definition_index": 0,
                 "format": "raw",
                 "input0": {
-                    "file_id": "file_xxx",
-                    "file_path": input_path
+                    "file_id": input_file_id,
                 },
                 "test_int": 5,
                 "test_float": 2.0,


### PR DESCRIPTION
- Files are referenced by file_id.
- file_upload can resolve a file_id by either providing a local file_path or the file content+type. (To support both the admin or client resolving the file)
- The client defines its own file_ids for locally uploaded files. (eg. "file_my_cool_hda")
- The client can optionally reference a file by file_path in order to reference hard-coded assets in the image. We should consider removing this in the future. (Should we just have hard-coded file_ids for these?)