### PR TITLE
Expose endpoint as environment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ LABEL version="1.0.0"
 LABEL tier="auto"
 
 # Setup Houdini environment
+ENV MYTHICA_ENDPOINT="https://api.mythica.gg"
 ENV SFX_CLIENT_ID=""
 ENV SFX_CLIENT_SECRET=""
 ENV HFS=/opt/houdini/build

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ WORKER_PIDS=()
 for ((i=0; i<$NUM_WORKERS; i++)); do
     CLIENT_PORT=$((BASE_CLIENT_PORT + i))
     ADMIN_PORT=$((BASE_ADMIN_PORT + i))
-    . /run/controller/.venv/bin/activate && python /run/controller/main.py --worker /run/houdini_worker --clientport $CLIENT_PORT --adminport $ADMIN_PORT &
+    . /run/controller/.venv/bin/activate && python /run/controller/main.py --worker /run/houdini_worker --clientport $CLIENT_PORT --adminport $ADMIN_PORT --endpoint $MYTHICA_ENDPOINT &
     WORKER_PIDS+=($!)
     echo "Started worker on ports client=$CLIENT_PORT admin=$ADMIN_PORT with PID ${WORKER_PIDS[-1]}"
 done


### PR DESCRIPTION
This is to help with a local development workflow.

In my local ".env" config I have this set to "http://host.docker.internal:8080". This allows the controller to connect to a locally running environment for resolving files.