### PR TITLE
Workaround supporting large input mesh files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ target_include_directories(mongoose PUBLIC
     third_party/mongoose
 )
 
+target_compile_definitions(mongoose PRIVATE
+    MG_MAX_RECV_SIZE=33554432  # 32MB
+)
+
 # Setup the path for houdini toolkit (cmake support)
 if(APPLE)
     # Use specific path for macOS builds


### PR DESCRIPTION
Websockets support automatic chunking of large messages into separate packets. However the mongoose implementation defaults to 4MB max message size which is not large enough to support reasonably sized mesh files. (~100k triangles)

The intention for scenetalk is to handle this chunking at the protocol level with partial frames. However this is not implemented yet so working around in the short term by increasing the websocket network buffer size.