### PR TITLE
Uninstall HDA files between non-incremental cooks

### DIFF
--- a/src/session.h
+++ b/src/session.h
@@ -11,6 +11,7 @@ struct HoudiniSession
     ~HoudiniSession();
 
     MOT_Director* m_director;
+    std::vector<std::string> m_installed_libraries;
     CookRequest m_state;
 };
 


### PR DESCRIPTION
We were hitting an issue when an artist updates an HDA in a package, but didn't bump the internal HDA version number.

This could cause there to be multiple versions of the same HDA node type installed with an ambiguous type name. This would cause the cook to often use the incorrect one leading to incorrect results.

Solving for now by uninstalling all HDAs between non-incremental cooks. In the future we can be more precise here to only uninstall the HDAs that are in conflict with the HDAs requested by the current CookRequest.