### PR TITLE
Fix FBX export parameters sometimes being incorrect

### DIFF
--- a/src/automation.cpp
+++ b/src/automation.cpp
@@ -565,10 +565,8 @@ bool export_geometry_with_format(MOT_Director* director, SOP_Node* sop, const GU
         export_node->setInt("exportkind", 0, 0.0f, 0);
         export_node->setInt("convertunits", 0, 0.0f, 1);
 
-        if (gdp->findAttribute(GA_ATTRIB_PRIMITIVE, GA_SCOPE_PUBLIC, "path") != nullptr)
-        {
-            export_node->setInt("buildfrompath", 0, 0.0f, 1);
-        }
+        bool build_from_path = gdp->findAttribute(GA_ATTRIB_PRIMITIVE, GA_SCOPE_PUBLIC, "path") != nullptr;
+        export_node->setInt("buildfrompath", 0, 0.0f, build_from_path ? 1 : 0);
     }
     else if (format == EOutputFormat::GLB)
     {


### PR DESCRIPTION
This would occur if you ran a tool with build_from_path=true, and then one where it is false. It is currently re-using the same export node between multiple jobs.

If we run into issues here again, a more robust fix would be to delete all of the export nodes when running cleanup_session. The performance overhead of recreating the output nodes is probably negligible.