### PR TITLE
Support for sub-meshes in raw geometry format

### DIFF
--- a/src/stream_writer.cpp
+++ b/src/stream_writer.cpp
@@ -73,65 +73,79 @@ void StreamWriter::file(const std::string& file_name, const std::vector<char>& f
     writeToStream(m_client_id, "file", "{\"file_name\":\"" + file_name + "\", \"content_base64\":\"" + encoded + "\"}");
 }
 
-void StreamWriter::geometry(const Geometry& geometry)
+void StreamWriter::geometry(const GeometrySet& geometry_set)
 {
     rmt_ScopedCPUSample(WriteGeometry, 0);
 
-    std::string json = "{\"points\":[";
-    for (size_t i = 0; i < geometry.points.size(); i++)
+    std::string json = "{";
+    
+    bool first_mesh = true;
+    for (const auto& [name, geometry] : geometry_set)
     {
-        json += std::to_string(geometry.points[i]);
-        if (i < geometry.points.size() - 1)
+        if (!first_mesh)
         {
             json += ",";
         }
-    }
-    if (geometry.normals.size() > 0)
-    {
-        json += "],\"normals\":[";
-        for (size_t i = 0; i < geometry.normals.size(); i++)
+        first_mesh = false;
+        
+        json += "\"" + name + "\":{\"points\":[";
+        for (size_t i = 0; i < geometry.points.size(); i++)
         {
-            json += std::to_string(geometry.normals[i]);
-            if (i < geometry.normals.size() - 1)
+            json += std::to_string(geometry.points[i]);
+            if (i < geometry.points.size() - 1)
             {
                 json += ",";
             }
         }
-    }
-    if (geometry.uvs.size() > 0)
-    {
-        json += "],\"uvs\":[";
-        for (size_t i = 0; i < geometry.uvs.size(); i++)
+        if (geometry.normals.size() > 0)
         {
-            json += std::to_string(geometry.uvs[i]);
-            if (i < geometry.uvs.size() - 1)
+            json += "],\"normals\":[";
+            for (size_t i = 0; i < geometry.normals.size(); i++)
+            {
+                json += std::to_string(geometry.normals[i]);
+                if (i < geometry.normals.size() - 1)
+                {
+                    json += ",";
+                }
+            }
+        }
+        if (geometry.uvs.size() > 0)
+        {
+            json += "],\"uvs\":[";
+            for (size_t i = 0; i < geometry.uvs.size(); i++)
+            {
+                json += std::to_string(geometry.uvs[i]);
+                if (i < geometry.uvs.size() - 1)
+                {
+                    json += ",";
+                }
+            }
+        }
+        if (geometry.colors.size() > 0)
+        {
+            json += "],\"colors\":[";
+            for (size_t i = 0; i < geometry.colors.size(); i++)
+            {
+                json += std::to_string(geometry.colors[i]);
+                if (i < geometry.colors.size() - 1)
+                {
+                    json += ",";
+                }
+            }
+        }
+        json += "],\"indices\":[";
+        for (size_t i = 0; i < geometry.indices.size(); i++)
+        {
+            json += std::to_string(geometry.indices[i]);
+            if (i < geometry.indices.size() - 1)
             {
                 json += ",";
             }
         }
+        json += "]}";
     }
-    if (geometry.colors.size() > 0)
-    {
-        json += "],\"colors\":[";
-        for (size_t i = 0; i < geometry.colors.size(); i++)
-        {
-            json += std::to_string(geometry.colors[i]);
-            if (i < geometry.colors.size() - 1)
-            {
-                json += ",";
-            }
-        }
-    }
-    json += "],\"indices\":[";
-    for (size_t i = 0; i < geometry.indices.size(); i++)
-    {
-        json += std::to_string(geometry.indices[i]);
-        if (i < geometry.indices.size() - 1)
-        {
-            json += ",";
-        }
-    }
-    json += "]}";
+    
+    json += "}";
 
     writeToStream(m_client_id, "geometry", json);
 }

--- a/src/stream_writer.h
+++ b/src/stream_writer.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "types.h"
+
 #include <string>
 #include <vector>
 
-struct Geometry;
 class WebSocket;
 
 enum class AutomationState
@@ -29,7 +30,7 @@ public:
     void admin_error(const std::string& message);
 
     void file(const std::string& file_name, const std::vector<char>& file_data);
-    void geometry(const Geometry& geometry);
+    void geometry(const GeometrySet& geometry_set);
     void file_resolve(const std::string& file_id);
 
 private:

--- a/src/types.h
+++ b/src/types.h
@@ -18,6 +18,7 @@ struct Geometry
     std::vector<float> colors;
     std::vector<int> indices;
 };
+using GeometrySet = std::map<std::string, Geometry>;
 
 struct FileParameter
 {

--- a/test_client.html
+++ b/test_client.html
@@ -299,7 +299,7 @@
     }
   ];
 
-  const SCHEMA_INDEX = 2;
+  const SCHEMA_INDEX = 0;
 
   // ================================================
   // Demo Materials
@@ -754,9 +754,12 @@
     }
 
     if (data.op === "geometry") {
-      const mesh = data.data;   // get the mesh from the payload
-      if (mesh.points && mesh.indices) {
-        createMeshFromData(mesh.points, mesh.indices, mesh.normals, mesh.uvs, mesh.colors);
+      const meshes = data.data;
+      if (Object.keys(meshes).length > 0) {
+        const mesh = Object.values(meshes)[0];
+        if (mesh.points && mesh.indices) {
+          createMeshFromData(mesh.points, mesh.indices, mesh.normals, mesh.uvs, mesh.colors);
+        }
       }
     }
 


### PR DESCRIPTION
This change allows the client to better handle displaying meshes with multiple packed LODs. This updates the raw exporter to be similar to the FBX exporter where the "path" attribute is used to define separate named sub-meshes for each LOD.

This will allow the client to decide how to best display the LOD data. Previously the mesh data for each LOD was all packed together into the same vertex buffer. 

For now in the example I am just making it display only the highest LOD.